### PR TITLE
Add option to trigger song recognition via VRCOSC UI

### DIFF
--- a/YeusepesModules/ShazamOSC/ShazamOSC.cs
+++ b/YeusepesModules/ShazamOSC/ShazamOSC.cs
@@ -59,6 +59,14 @@ namespace YeusepesModules.ShazamOSC
 
         public ShazamRecognitionContext RecognitionContext { get; } = new ShazamRecognitionContext();
 
+        public void TriggerRecognition()
+        {
+            // Cancel any in‑flight run, then start a new one
+            _recognitionCts?.Cancel();
+            _recognitionCts = new CancellationTokenSource();
+            _ = Task.Run(() => RecognizeFromDesktop(_recognitionCts.Token), _recognitionCts.Token);
+        }
+
         protected override void OnPreLoad()
         {
             LogDebug("OnPreLoad: registering parameters and settings.");
@@ -171,10 +179,7 @@ namespace YeusepesModules.ShazamOSC
                 bool shouldStart = parameter.GetValue<bool>();
                 if (shouldStart)
                 {
-                    // cancel any in‑flight run, then start a new one
-                    _recognitionCts?.Cancel();
-                    _recognitionCts = new CancellationTokenSource();
-                    _ = Task.Run(() => RecognizeFromDesktop(_recognitionCts.Token), _recognitionCts.Token);
+                    TriggerRecognition();
                 }
                 else
                 {

--- a/YeusepesModules/ShazamOSC/UI/LastRecognized.xaml
+++ b/YeusepesModules/ShazamOSC/UI/LastRecognized.xaml
@@ -28,7 +28,9 @@
     <!-- Outer rounded border -->
     <Border CornerRadius="12"          
           ClipToBounds="True"
-          Padding="10">
+          Padding="10"
+          Cursor="Hand"
+          MouseLeftButtonDown="OnRecognizeClick">
         <Border.Background>
             <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
                 <!-- your “shame” blue -->

--- a/YeusepesModules/ShazamOSC/UI/LastRecognized.xaml.cs
+++ b/YeusepesModules/ShazamOSC/UI/LastRecognized.xaml.cs
@@ -10,7 +10,7 @@ using System.Windows.Media.Animation;
 using YeusepesModules.ShazamOSC.ShazamAPI;
 
 namespace YeusepesModules.ShazamOSC.UI
-{    
+{
 
     public class ShazamRecognitionContext : INotifyPropertyChanged
     {
@@ -142,6 +142,7 @@ namespace YeusepesModules.ShazamOSC.UI
     /// </summary>
     public partial class LastRecognized : UserControl
     {
+        private readonly ShazamOSC _module;
         private readonly LevelToScaleConverter _circleConverter = new LevelToScaleConverter();
         private readonly InverseLevelToScaleConverter _logoConverter = new InverseLevelToScaleConverter();
         private readonly SineEase _easing = new SineEase { EasingMode = EasingMode.EaseOut };
@@ -149,6 +150,7 @@ namespace YeusepesModules.ShazamOSC.UI
         public LastRecognized(ShazamOSC module)
         {
             InitializeComponent();
+            _module = module;
             DataContext = module.RecognitionContext;
 
             module.RecognitionContext.PropertyChanged += (s, e) =>
@@ -174,7 +176,10 @@ namespace YeusepesModules.ShazamOSC.UI
                 transform.BeginAnimation(ScaleTransform.ScaleYProperty, anim);
             }));
         }
+
+        private void OnRecognizeClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            _module.TriggerRecognition();
+        }
     }
-
-
 }


### PR DESCRIPTION
Runtime view ShazamOSC blue box now can be clicked to trigger the song recognition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- The last recognized track display is now interactive and clickable, enabling users to trigger a new recognition scan directly from the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->